### PR TITLE
Add basic browser-based Snake game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Snake Game</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      .game-wrapper {
+        text-align: center;
+      }
+
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.5rem;
+      }
+
+      .meta {
+        margin-bottom: 0.75rem;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        font-size: 0.95rem;
+      }
+
+      canvas {
+        display: block;
+        background: #111827;
+        border: 2px solid #334155;
+        box-shadow: 0 0 0 2px #1e293b;
+      }
+
+      .hint {
+        margin-top: 0.75rem;
+        color: #94a3b8;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="game-wrapper">
+      <h1>Snake</h1>
+      <div class="meta">
+        <div>Score: <span id="score">0</span></div>
+        <div>Best: <span id="best">0</span></div>
+      </div>
+      <canvas id="board" width="400" height="400" aria-label="Snake board"></canvas>
+      <p class="hint">Use arrow keys or WASD to move. Press Space to restart after game over.</p>
+    </main>
+
+    <script>
+      const canvas = document.getElementById('board');
+      const ctx = canvas.getContext('2d');
+      const scoreEl = document.getElementById('score');
+      const bestEl = document.getElementById('best');
+
+      const cellSize = 20;
+      const tileCount = canvas.width / cellSize;
+
+      let snake;
+      let direction;
+      let queuedDirection;
+      let food;
+      let score;
+      let bestScore = Number(localStorage.getItem('snake-best') || 0);
+      let gameOver;
+
+      bestEl.textContent = bestScore;
+
+      function resetGame() {
+        snake = [
+          { x: 10, y: 10 },
+          { x: 9, y: 10 },
+          { x: 8, y: 10 }
+        ];
+        direction = { x: 1, y: 0 };
+        queuedDirection = direction;
+        score = 0;
+        gameOver = false;
+        scoreEl.textContent = score;
+        placeFood();
+      }
+
+      function placeFood() {
+        do {
+          food = {
+            x: Math.floor(Math.random() * tileCount),
+            y: Math.floor(Math.random() * tileCount)
+          };
+        } while (snake.some(segment => segment.x === food.x && segment.y === food.y));
+      }
+
+      function drawCell(x, y, color) {
+        ctx.fillStyle = color;
+        ctx.fillRect(x * cellSize, y * cellSize, cellSize - 1, cellSize - 1);
+      }
+
+      function draw() {
+        ctx.fillStyle = '#020617';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        drawCell(food.x, food.y, '#f43f5e');
+
+        snake.forEach((segment, idx) => {
+          drawCell(segment.x, segment.y, idx === 0 ? '#22c55e' : '#16a34a');
+        });
+
+        if (gameOver) {
+          ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.fillStyle = '#f8fafc';
+          ctx.font = 'bold 28px Arial';
+          ctx.textAlign = 'center';
+          ctx.fillText('Game Over', canvas.width / 2, canvas.height / 2 - 8);
+          ctx.font = '16px Arial';
+          ctx.fillText('Press Space to restart', canvas.width / 2, canvas.height / 2 + 20);
+        }
+      }
+
+      function step() {
+        if (gameOver) {
+          draw();
+          return;
+        }
+
+        direction = queuedDirection;
+        const head = {
+          x: snake[0].x + direction.x,
+          y: snake[0].y + direction.y
+        };
+
+        const hitWall = head.x < 0 || head.y < 0 || head.x >= tileCount || head.y >= tileCount;
+        const hitSelf = snake.some(segment => segment.x === head.x && segment.y === head.y);
+
+        if (hitWall || hitSelf) {
+          gameOver = true;
+          draw();
+          return;
+        }
+
+        snake.unshift(head);
+
+        if (head.x === food.x && head.y === food.y) {
+          score += 1;
+          scoreEl.textContent = score;
+          if (score > bestScore) {
+            bestScore = score;
+            bestEl.textContent = bestScore;
+            localStorage.setItem('snake-best', bestScore);
+          }
+          placeFood();
+        } else {
+          snake.pop();
+        }
+
+        draw();
+      }
+
+      function handleDirection(next) {
+        if (next.x === -direction.x && next.y === -direction.y) {
+          return;
+        }
+        queuedDirection = next;
+      }
+
+      document.addEventListener('keydown', event => {
+        const key = event.key.toLowerCase();
+
+        if (gameOver && key === ' ') {
+          resetGame();
+          draw();
+          return;
+        }
+
+        switch (key) {
+          case 'arrowup':
+          case 'w':
+            handleDirection({ x: 0, y: -1 });
+            break;
+          case 'arrowdown':
+          case 's':
+            handleDirection({ x: 0, y: 1 });
+            break;
+          case 'arrowleft':
+          case 'a':
+            handleDirection({ x: -1, y: 0 });
+            break;
+          case 'arrowright':
+          case 'd':
+            handleDirection({ x: 1, y: 0 });
+            break;
+          default:
+            break;
+        }
+      });
+
+      resetGame();
+      draw();
+      setInterval(step, 110);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained browser demo of a classic Snake game that can be opened locally without build steps. 
- Offer a simple playable example that demonstrates canvas rendering, keyboard input handling, and persistent high-score storage. 

### Description
- Add a single-file `index.html` that implements the game UI, canvas board, HUD (score/best), and minimal styling. 
- Implement core gameplay: snake state, movement queuing, food spawning avoiding the snake, collision detection (wall/self), growth on food, and a `setInterval` game loop. 
- Add keyboard controls (arrow keys and WASD), prevent immediate 180° turns, and enable restart on Space after game over. 
- Persist the best score using `localStorage` and update the HUD in real time. 

### Testing
- Served the page locally with `python3 -m http.server 4173` and validated an `HTTP/1.0 200 OK` response using `curl -I`, which succeeded. 
- Captured a browser screenshot using Playwright with Firefox, which succeeded and produced the screenshot artifact. 
- Attempted to capture with Playwright Chromium, which failed due to a browser crash (`SIGSEGV`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a417cd06548330ad6a41ca828dd031)